### PR TITLE
Removed hard urllib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 python-dotenv~=1.0.1
-urllib3~=2.2.3
 requests~=2.32.3

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     packages=find_packages(exclude=['tests', 'examples']),
     install_requires=[
         "python-dotenv~=1.0.1",
-        "urllib3~=2.2.3",
         "requests~=2.32.3"
     ],
     description='A Python Package for interacting with the Satisfactory Dedicated Server API',


### PR DESCRIPTION
I like to use your library on a environment without venv, but it still relies on urllib version < 2 (1.26.20).

As the requests package is installing the newest version of urllib anyways I have removed the hard dependency of it in the requirements.

This way your library can work with a previous version of urllib just fine when dependency checking.

Tested with urllib 1.26.20 without any problems.


